### PR TITLE
Change font import to HTTPS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
  
  
-@import url(http://fonts.googleapis.com/css?family=Audiowide);
+@import url(https://fonts.googleapis.com/css?family=Audiowide);
 
 .code{
 	


### PR DESCRIPTION
## Summary
- use HTTPS URL for Google Fonts import in CSS

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_683f8b058744832cabf26808b5eec52b